### PR TITLE
Documentation in code

### DIFF
--- a/Sources/OpenFeature/BaseEvaluation.swift
+++ b/Sources/OpenFeature/BaseEvaluation.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// This is a common interface between the evaluation results that providers return and what is given to the end users.
+/// ``ValueType`` is the type of flag being evaluated.
 public protocol BaseEvaluation {
     associatedtype ValueType
     var value: ValueType { get }

--- a/Sources/OpenFeature/EvaluationContext.swift
+++ b/Sources/OpenFeature/EvaluationContext.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Container for arbitrary contextual data that can be used as a basis for dynamic evaluation.
 public protocol EvaluationContext: Structure {
     func getTargetingKey() -> String
 

--- a/Sources/OpenFeature/FeatureProvider.swift
+++ b/Sources/OpenFeature/FeatureProvider.swift
@@ -5,10 +5,10 @@ public protocol FeatureProvider {
     var hooks: [any Hook] { get }
     var metadata: Metadata { get }
 
-    // Called by OpenFeatureAPI whenever the new Provider is registered
+    /// Called by OpenFeatureAPI whenever the new Provider is registered
     func initialize(initialContext: EvaluationContext?) async
 
-    // Called by OpenFeatureAPI whenever a new EvaluationContext is set by the application
+    /// Called by OpenFeatureAPI whenever a new EvaluationContext is set by the application
     func onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) async
 
     func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws

--- a/Sources/OpenFeature/Features.swift
+++ b/Sources/OpenFeature/Features.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// An API for the type-specific fetch methods offered to users.
 public protocol Features {
     // MARK: Generics
     func getValue<T: AllowedFlagValueType>(key: String, defaultValue: T) -> T

--- a/Sources/OpenFeature/FlagEvaluationDetails.swift
+++ b/Sources/OpenFeature/FlagEvaluationDetails.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Contains information about how the evaluation happened, including any resolved values.
 public struct FlagEvaluationDetails<T: Equatable>: BaseEvaluation, Equatable {
     public var flagKey: String
     public var value: T

--- a/Sources/OpenFeature/Hook.swift
+++ b/Sources/OpenFeature/Hook.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// An extension point which can run around flag resolution.
+/// They are intended to be used as a way to add custom logic to the lifecycle of flag evaluation.
 public protocol Hook {
     associatedtype HookValue: AllowedFlagValueType
 
@@ -19,7 +21,9 @@ extension Hook {
         // Default implementation
     }
 
-    public func after<HookValue>(ctx: HookContext<HookValue>, details: FlagEvaluationDetails<HookValue>, hints: [String: Any]) {
+    public func after<HookValue>(
+        ctx: HookContext<HookValue>, details: FlagEvaluationDetails<HookValue>, hints: [String: Any]
+    ) {
         // Default implementation
     }
 

--- a/Sources/OpenFeature/HookContext.swift
+++ b/Sources/OpenFeature/HookContext.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// A data struct to hold immutable context that ``Hook`` instances use.
 public struct HookContext<T> {
     var flagKey: String
     var type: FlagValueType

--- a/Sources/OpenFeature/HookSupport.swift
+++ b/Sources/OpenFeature/HookSupport.swift
@@ -2,9 +2,8 @@ import Foundation
 import os
 
 class HookSupport {
-
     var logger = Logger()
-    
+
     func errorHooks<T>(
         flagValueType: FlagValueType, hookCtx: HookContext<T>, error: Error, hooks: [any Hook], hints: [String: Any]
     ) {
@@ -13,8 +12,9 @@ class HookSupport {
             .forEach { $0.error(ctx: hookCtx, error: error, hints: hints) }
     }
 
-    func afterAllHooks<T>(flagValueType: FlagValueType, hookCtx: HookContext<T>, hooks: [any Hook], hints: [String: Any])
-    {
+    func afterAllHooks<T>(
+        flagValueType: FlagValueType, hookCtx: HookContext<T>, hooks: [any Hook], hints: [String: Any]
+    ) {
         hooks
             .filter { $0.supportsFlagValueType(flagValueType: flagValueType) }
             .forEach { $0.finallyAfter(ctx: hookCtx, hints: hints) }
@@ -32,7 +32,8 @@ class HookSupport {
             .forEach { $0.after(ctx: hookCtx, details: details, hints: hints) }
     }
 
-    func beforeHooks<T>(flagValueType: FlagValueType, hookCtx: HookContext<T>, hooks: [any Hook], hints: [String: Any]) {
+    func beforeHooks<T>(flagValueType: FlagValueType, hookCtx: HookContext<T>, hooks: [any Hook], hints: [String: Any])
+    {
         hooks
             .reversed()
             .filter { $0.supportsFlagValueType(flagValueType: flagValueType) }

--- a/Sources/OpenFeature/MutableContext.swift
+++ b/Sources/OpenFeature/MutableContext.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// The ``MutableContext`` is an ``EvaluationContext`` implementation which is not threadsafe, and whose attributes can
+/// be modified after instantiation.
 public class MutableContext: EvaluationContext {
     private var targetingKey: String
     private var structure: MutableStructure

--- a/Sources/OpenFeature/MutableStructure.swift
+++ b/Sources/OpenFeature/MutableStructure.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// The ``MutableStructure`` is a ``Structure`` implementation which is not threadsafe, and whose attributes can
+/// be modified after instantiation.
 public class MutableStructure: Structure {
     private var attributes: [String: Value]
 

--- a/Sources/OpenFeature/NoOpProvider.swift
+++ b/Sources/OpenFeature/NoOpProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// A ``FeatureProvider`` that simply returns the default values passed to it.
 class NoOpProvider: FeatureProvider {
     public static let passedInDefault = "Passed in default"
 

--- a/Sources/OpenFeature/OpenFeatureClient.swift
+++ b/Sources/OpenFeature/OpenFeatureClient.swift
@@ -39,21 +39,24 @@ public class OpenFeatureClient: Client {
 
 extension OpenFeatureClient {
     // MARK: Generics
-    public func getValue<T>(key: String, defaultValue: T) -> T where T : AllowedFlagValueType {
+    public func getValue<T>(key: String, defaultValue: T) -> T where T: AllowedFlagValueType {
         getDetails(key: key, defaultValue: defaultValue).value
     }
 
-    public func getValue<T>(key: String, defaultValue: T, options: FlagEvaluationOptions) -> T where T : AllowedFlagValueType {
+    public func getValue<T>(key: String, defaultValue: T, options: FlagEvaluationOptions) -> T
+    where T: AllowedFlagValueType {
         getDetails(key: key, defaultValue: defaultValue, options: options).value
     }
 
     public func getDetails<T>(key: String, defaultValue: T)
-    -> FlagEvaluationDetails<T> where T : AllowedFlagValueType, T : Equatable {
+        -> FlagEvaluationDetails<T> where T: AllowedFlagValueType, T: Equatable
+    {
         getDetails(key: key, defaultValue: defaultValue, options: FlagEvaluationOptions())
     }
 
     public func getDetails<T>(key: String, defaultValue: T, options: FlagEvaluationOptions)
-    -> FlagEvaluationDetails<T> where T : AllowedFlagValueType, T : Equatable {
+        -> FlagEvaluationDetails<T> where T: AllowedFlagValueType, T: Equatable
+    {
         evaluateFlag(
             flagValueType: T.flagValueType,
             key: key,

--- a/Sources/OpenFeature/Structure.swift
+++ b/Sources/OpenFeature/Structure.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Represents a potentially nested object type which is used to represent
+/// structured data.
 public protocol Structure {
     func keySet() -> Set<String>
     func getValue(key: String) -> Value?

--- a/Sources/OpenFeature/Value.swift
+++ b/Sources/OpenFeature/Value.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// Values serve as a generic return type for structure data from providers.
+/// Providers may deal in JSON, protobuf, XML or some other data-interchange format.
+/// This intermediate representation provides a good medium of exchange.
 public enum Value: Equatable {
     case boolean(Bool)
     case string(String)

--- a/Tests/OpenFeatureTests/Helpers/BooleanHookMock.swift
+++ b/Tests/OpenFeatureTests/Helpers/BooleanHookMock.swift
@@ -27,7 +27,8 @@ class BooleanHookMock: Hook {
         self.addEval(self.prefix.isEmpty ? "before" : "\(self.prefix) before")
     }
 
-    func after<HookValue>(ctx: HookContext<HookValue>, details: FlagEvaluationDetails<HookValue>, hints: [String: Any]) {
+    func after<HookValue>(ctx: HookContext<HookValue>, details: FlagEvaluationDetails<HookValue>, hints: [String: Any])
+    {
         afterCalled += 1
         self.addEval(self.prefix.isEmpty ? "after" : "\(self.prefix) after")
     }

--- a/Tests/OpenFeatureTests/Helpers/IntHookMock.swift
+++ b/Tests/OpenFeatureTests/Helpers/IntHookMock.swift
@@ -27,7 +27,8 @@ class IntHookMock: Hook {
         self.addEval(self.prefix.isEmpty ? "before" : "\(self.prefix) before")
     }
 
-    func after<HookValue>(ctx: HookContext<HookValue>, details: FlagEvaluationDetails<HookValue>, hints: [String: Any]) {
+    func after<HookValue>(ctx: HookContext<HookValue>, details: FlagEvaluationDetails<HookValue>, hints: [String: Any])
+    {
         afterCalled += 1
         self.addEval(self.prefix.isEmpty ? "after" : "\(self.prefix) after")
     }


### PR DESCRIPTION
This also includes some smaller formatting changes suggested by the linter, unrelated to documentation.
Note that most of the docs content is inspired by the JavaDocs in the Java OpenFeature SDK [here](https://github.com/open-feature/java-sdk), since the generic abstractions and classes/models are pretty much the same ([Value example](https://github.com/open-feature/java-sdk/blob/8b9e0500924475bccd3f069f5967b5af59d50f12/src/main/java/dev/openfeature/sdk/Value.java))