### PR TITLE
Restructure setters in OpenFeatureAPI

### DIFF
--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -18,12 +18,11 @@ public class OpenFeatureAPI {
     }
 
     public func setProvider(provider: FeatureProvider, initialContext: EvaluationContext?) async {
-        await provider.initialize(initialContext: initialContext ?? self._context)
         self._provider = provider
-        guard let newEvaluationContext = initialContext else {
-            return
+        if let context = initialContext {
+            self._context = context
         }
-        self._context = newEvaluationContext
+        await provider.initialize(initialContext: self._context)
     }
 
     public func getProvider() -> FeatureProvider? {
@@ -35,12 +34,8 @@ public class OpenFeatureAPI {
     }
 
     public func setEvaluationContext(evaluationContext: EvaluationContext) async {
-        await getProvider()?.onContextSet(oldContext: self._context, newContext: evaluationContext)
-        // A provider evaluation reading the global ctx at this point would fail due to stale cache.
-        // To prevent this, the provider should internally manage the ctx to use on each evaluation, and
-        // make sure it's aligned with the values in the cache at all times. If no guarantees are offered by
-        // the provider, the application can expect STALE resolves while setting a new global ctx
         self._context = evaluationContext
+        await getProvider()?.onContextSet(oldContext: self._context, newContext: evaluationContext)
     }
 
     public func getEvaluationContext() -> EvaluationContext? {


### PR DESCRIPTION
The idea is to set the global parameters _before_ applying any side effect within the underlying Provider.
For example, while the Provider is processing a new context (i.e. `onContextSet()` is running), that new context is already set in the global API and it is the context used for future evaluation reads: this makes it less likely for the Providers to return data associated to an older evaluation context _after_ the application has already called `setEvaluationContext()` 

### Step by step scenario
- "contextA" and flag cache for "contextA" are used during a certain app's session
- The application calls "setEvaluationContext(contextB)"
- While the provider is fetching the flags data for contextB, the application calls the provider's evaluation APIs (already expecting data for "contextB")
  - Before this PR, it's possible that the global context is still "contextA" and that the underlying Provide hasn't yet updated the cache with contextB data, resulting in contextA data being returned (while the app expects contextB data)

Same change on the Kotlin SDK: https://github.com/spotify/openfeature-kotlin-sdk/pull/30